### PR TITLE
Ingest dispatcher fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>easy-ingest-flow</artifactId>
-            <version>1.0.2</version>
+            <version>1.x-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>


### PR DESCRIPTION
Fix for EASY-Ingest-Dispatcher. Due to the changes in EASY-Ingest-Flow of last week, the SNAPSHOT version of EASY-Ingest-Dispatcher was broken. Two notable changes in this PR are:
* The dependency to EASY-Ingest-Flow now points to `1.x.SNAPSHOT`.
* New names from EASY-Ingest-Flow are used and imported here.

Notice that this PR is mutually dependent with [EASY-Ingest-Flow#37](https://github.com/DANS-KNAW/easy-ingest-flow/pull/37).

@DANS-KNAW/easy - ready for review!