### PR TITLE
EASY-1040. Make virus scan command configurable

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -21,3 +21,4 @@ pid-generator.url={{ easy_ingest_dispatcher_pid_generator_url }}
 solr.update-url={{ easy_ingest_dispatcher_solr_update_url }}
 redirect-unset-url=http://unset.dans.knaw.nl
 license.resources={{ easy_ingest_dispatcher_license_resources }}
+virusscan.cmd={{ easy_ingest_dispatcher_virusscan_cmd }}

--- a/src/main/scala/nl/knaw/dans/easy/ingest_dispatcher/EasyIngestDispatcher.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest_dispatcher/EasyIngestDispatcher.scala
@@ -150,7 +150,8 @@ object EasyIngestDispatcher {
       sdoSetDir = new File(props.getString("staging.root-dir"), deposit.getName),
       postgresURL = props.getString("fsrdb.connection-url"),
       solr = props.getString("solr.update-url"),
-      pidgen = props.getString("pid-generator.url"))
+      pidgen = props.getString("pid-generator.url"),
+      virusscanCmd = props.getString("virusscan.cmd"))
   }
 
   def getUserId(depositDir: File): String = new PropertiesConfiguration(new File(depositDir, "deposit.properties")).getString("depositor.userId")


### PR DESCRIPTION
Fixes EASY-1040

#### When applied it will
* Make the command that implements the virus scanning step in the ingest flow configurable 

#### Where should the reviewer @DANS-KNAW/easy start?


#### How should this be manually tested?
In `application.properties` configure `virusscanner.cmd` to something else and see what happens.

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 

