### PR TITLE
EASY-1008 DATASET_LICENSE for Mendeley

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -22,3 +22,4 @@ solr.update-url={{ easy_ingest_dispatcher_solr_update_url }}
 redirect-unset-url=http://unset.dans.knaw.nl
 license.resources={{ easy_ingest_dispatcher_license_resources }}
 virusscan.cmd={{ easy_ingest_dispatcher_virusscan_cmd }}
+custom-dataset-license-text={{ easy_ingest_dispatcher_mendeley_license_text }}

--- a/src/main/scala/nl/knaw/dans/easy/ingest_dispatcher/EasyIngestDispatcher.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest_dispatcher/EasyIngestDispatcher.scala
@@ -144,6 +144,7 @@ object EasyIngestDispatcher {
       checkInterval = props.getInt("check.interval"),
       maxCheckCount = props.getInt("max.check.count"),
       ownerId = getUserId(deposit),
+      customDatasetLicenseText = props.getString("custom-dataset-license-text"),
       datasetAccessBaseUrl = props.getString("easy.dataset-access-base-url"),
       depositDir = deposit,
       licenseResourceDir = new File(props.getString("license.resources")),


### PR DESCRIPTION
Fixes EASY-1008

#### When applied it will
* Add a custom dataset license text in de Mendeley flow

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* Do a deposit on `deasy` with the helper scripts in `easy-sword2/src/test/resources` and user/password `mendeltest`/`mendeltest`
* Check the `DATASET_LICENSE` of the resulting dataset. Is should contain a short message referring to the contract with Mendeley.

#### related pull requests on github
https://github.com/DANS-KNAW/easy-dtap/pull/36
https://github.com/DANS-KNAW/easy-ingest-flow/pull/53